### PR TITLE
Update compile and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ To compile jq to WebAssembly, run the `compile.sh` code within an environment th
 
 To set up your environment:
 
-```bash
+```sh
 # Make sure to use "--recursive" so the jq submodule is initialized
 $ git clone --recursive https://github.com/robertaboukhalil/jqkungfu.git
 
 # Build the Docker image with needed dependencies
-$ docker build -t jqkungfu .
+$ docker buildx build -t jqkungfu .
 
 # Compile to WebAssembly
-$ docker run --rm -it -v $(pwd):/src --entrypoint ./compile.sh jqkungfu
+$ docker run --rm -it -v .:/src --entrypoint ./compile.sh jqkungfu
 ```
 
 ## Learn More

--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@ A [jq](https://github.com/stedolan/jq/) playground, powered by WebAssembly.
 * [jq Tutorial](https://sandbox.bio/tutorials?id=jq-intro)
 * [Use jq in your own web apps](https://github.com/biowasm/biowasm/tree/main/tools/jq#jqwasm)
 
-
 ## How?
 
 jqkungfu was built by compiling [jq](https://github.com/stedolan/jq/) to WebAssembly, so that it runs in the browser.
 
 The advantages of this approach are:
 
-- **Speed**: After the initial load time, jq queries are very fast because there are no round trips to a server
-- **Security**: This approach runs jq within the browser; otherwise, we would need to carefully secure the app so that users can't run arbitrary commands on the server!
-- **Convenience**: The app is purely front-end and is hosted as static files on a cloud storage provider
+* **Speed**: After the initial load time, jq queries are very fast because there are no round trips to a server
+* **Security**: This approach runs jq within the browser; otherwise, we would need to carefully secure the app so that users can't run arbitrary commands on the server!
+* **Convenience**: The app is purely front-end and is hosted as static files on a cloud storage provider
 
 ## Launch locally
 
@@ -29,7 +28,6 @@ python3 -m http.server 9999
 ```
 
 Then open [http://localhost:9999](http://localhost:9999) in your browser.
-
 
 ## Compile to WebAssembly (optional)
 

--- a/compile.sh
+++ b/compile.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env sh
 
+# Echo function that behaves consistently across shells
+echo() { printf '%s\n' "$*";}
+
 # Compile jq to WebAssembly
 
 # Need Emscripten installed
 if ! command -v emcc > /dev/null 2>&1; then
-  printf '%s\n' \
-    'You need Emscripten to compile jq to WebAssembly.' \
-    'See the setup instructions in the README file.'
+  echo 'You need Emscripten to compile jq to WebAssembly. See the setup instructions in the README file.'
   exit 2
 fi >&2
 
@@ -32,5 +33,5 @@ emmake make \
   EXEEXT=.js \
   CFLAGS="-O2 -s EXPORTED_RUNTIME_METHODS=['callMain']"
 
-mkdir -p -- ../build/
-mv -- jq.js jq.wasm ../build/
+mkdir -p ../build/
+mv jq.js jq.wasm ../build/

--- a/compile.sh
+++ b/compile.sh
@@ -1,20 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Compile jq to WebAssembly
 
 # Need Emscripten installed
-[[ ! $(command -v emcc --version) ]] && \
-  echo "You need Emscripten to compile jq to WebAssembly. See the setup instructions in the README file." && \
-  exit
+if ! command -v emcc > /dev/null 2>&1; then
+  printf '%s\n' \
+    'You need Emscripten to compile jq to WebAssembly.' \
+    'See the setup instructions in the README file.'
+  exit 2
+fi >&2
 
 # Update jq repo and its submodules
-cd jq
+cd jq || exit 2
 git submodule update --init --recursive
 
 # Edit main.c so that reset option flags to 0 every time we call the main() function
 # This is needed because we're not exiting after each main() call; otherwise, the
 # "Sort Keys" feature wouldn't work
-git apply ../jq.patch
+git apply ../jq.patch 2> /dev/null
 
 # Generate ./configure file
 autoreconf -fi
@@ -29,5 +32,5 @@ emmake make \
   EXEEXT=.js \
   CFLAGS="-O2 -s EXPORTED_RUNTIME_METHODS=['callMain']"
 
-mkdir -p ../build/
-mv jq.{js,wasm} ../build/
+mkdir -p -- ../build/
+mv -- jq.js jq.wasm ../build/


### PR DESCRIPTION
Fiabilize and make compile.sh use POSIX grammar.

Update build instructions to docker buildx as build is deprecated
and soon removed.
